### PR TITLE
Changed 'graph3Traces' to a method and enabling translation of graph hover label

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -604,7 +604,9 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces()" :layout="graph3Layout(
+      <graph :traces="graph3Traces(
+        '% Infected'
+      )" :layout="graph3Layout(
         'Comment les masques réduisent les infections',
         'Pourcentage de gens portant un masque',
         'Pourcentage de gens qui vont être infectés'

--- a/index-fr.html
+++ b/index-fr.html
@@ -604,7 +604,7 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces" :layout="graph3Layout(
+      <graph :traces="graph3Traces()" :layout="graph3Layout(
         'Comment les masques réduisent les infections',
         'Pourcentage de gens portant un masque',
         'Pourcentage de gens qui vont être infectés'

--- a/index-he.html
+++ b/index-he.html
@@ -607,7 +607,9 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces('נדבקים %')" :layout="graph3Layout(
+      <graph :traces="graph3Traces(
+        'נדבקים %'
+        )" :layout="graph3Layout(
         'כיצד מסיכות מקטינות אחוזי ההדבקה',
         'אחוז האנשים העוטים מסיכה',
         'אחוז האנשים שיידבקו'

--- a/index-he.html
+++ b/index-he.html
@@ -607,7 +607,7 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces" :layout="graph3Layout(
+      <graph :traces="graph3Traces('נדבקים %')" :layout="graph3Layout(
         'כיצד מסיכות מקטינות אחוזי ההדבקה',
         'אחוז האנשים העוטים מסיכה',
         'אחוז האנשים שיידבקו'

--- a/index-it.html
+++ b/index-it.html
@@ -604,7 +604,7 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces" :layout="graph3Layout(
+      <graph :traces="graph3Traces()" :layout="graph3Layout(
         'Come le Mascherine Abbassano Il Numero di Infezioni',
         'Percentuale di Persone che Porta Mascherine',
         'Percentuale di Persone Infette Al Termine dell\'Epidemia'

--- a/index-it.html
+++ b/index-it.html
@@ -604,7 +604,9 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces()" :layout="graph3Layout(
+      <graph :traces="graph3Traces(
+        '% Infected'
+        )" :layout="graph3Layout(
         'Come le Mascherine Abbassano Il Numero di Infezioni',
         'Percentuale di Persone che Porta Mascherine',
         'Percentuale di Persone Infette Al Termine dell\'Epidemia'

--- a/index-pt.html
+++ b/index-pt.html
@@ -605,7 +605,9 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces()" :layout="graph3Layout(
+      <graph :traces="graph3Traces(
+        '% Infected'
+        )" :layout="graph3Layout(
         'Como as máscaras reduzem o número de infecções',
         'Percentual da população que usa máscara',
         'Percentual da população que será infectada'

--- a/index-pt.html
+++ b/index-pt.html
@@ -605,7 +605,7 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces" :layout="graph3Layout(
+      <graph :traces="graph3Traces()" :layout="graph3Layout(
         'Como as máscaras reduzem o número de infecções',
         'Percentual da população que usa máscara',
         'Percentual da população que será infectada'

--- a/index.html
+++ b/index.html
@@ -604,7 +604,9 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces()" :layout="graph3Layout(
+      <graph :traces="graph3Traces(
+        '% Infected'
+        )" :layout="graph3Layout(
         'How Masks Reduce Infections',
         'Percentage of People Who Wear Masks',
         'Percentage of People Who Will Be Infected'

--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@
         <slider v-model="ein" :min="0" :max="0.99" :step="0.01"></slider>
       </label>
 
-      <graph :traces="graph3Traces" :layout="graph3Layout(
+      <graph :traces="graph3Traces()" :layout="graph3Layout(
         'How Masks Reduce Infections',
         'Percentage of People Who Wear Masks',
         'Percentage of People Who Will Be Infected'

--- a/js/vue-definitions.js
+++ b/js/vue-definitions.js
@@ -321,6 +321,34 @@ let app = new Vue({
       }
     },
 
+    graph3Traces(percentInfected='% Infected') {
+      return [
+        {
+          name: percentInfected,
+          x: this.indexArray,
+          y: this.indexArray.map(p => Math.max(1 + gsl_sf_lambert_W0(- this.R0withmask(p) * Math.exp(-this.R0withmask(p)))/this.R0withmask(p), 0) ),
+          type: 'scatter',
+          mode: 'lines',
+          fill: 'tozeroy',
+          fillcolor: 'rgba(255, 50, 50, 0.2)',
+          line: {
+            color: this.graphTraceColor,
+            width: 4
+          }
+        },
+        {
+          x: [0,1],
+          y: [1,1],
+          type: 'scatter',
+          mode: 'lines',
+          fill: 'tonexty',
+          fillcolor: 'rgba(50, 255, 50, 0.2)',
+          line: {color: "transparent"},
+          hoverinfo: 'none'
+        }
+      ]
+    },
+
   },
 
   computed: {
@@ -369,33 +397,7 @@ let app = new Vue({
       ]
     },
 
-    graph3Traces() {
-      return [
-        {
-          name: '% Infected',
-          x: this.indexArray,
-          y: this.indexArray.map(p => Math.max(1 + gsl_sf_lambert_W0(- this.R0withmask(p) * Math.exp(-this.R0withmask(p)))/this.R0withmask(p), 0) ),
-          type: 'scatter',
-          mode: 'lines',
-          fill: 'tozeroy',
-          fillcolor: 'rgba(255, 50, 50, 0.2)',
-          line: {
-            color: this.graphTraceColor,
-            width: 4
-          }
-        },
-        {
-          x: [0,1],
-          y: [1,1],
-          type: 'scatter',
-          mode: 'lines',
-          fill: 'tonexty',
-          fillcolor: 'rgba(50, 255, 50, 0.2)',
-          line: {color: "transparent"},
-          hoverinfo: 'none'
-        }
-      ]
-    },
+    
 
     config() {
       return {

--- a/js/vue-definitions.js
+++ b/js/vue-definitions.js
@@ -321,7 +321,7 @@ let app = new Vue({
       }
     },
 
-    graph3Traces(percentInfected='% Infected') {
+    graph3Traces(percentInfected) {
       return [
         {
           name: percentInfected,


### PR DESCRIPTION
Changed `graph3Traces` to a method and enabled translation of graph hover label. In this PR I translated only the Hebrew version, and used the English term ('% infected') as the default value for other languages