### PR TITLE
Fix typo in a comment in mathmodel.ipynb

### DIFF
--- a/model/mathmodel.ipynb
+++ b/model/mathmodel.ipynb
@@ -97,7 +97,7 @@
     "y = x.copy().T # transpose \n",
     "z = 2.5 * (1-x*y)**2\n",
     "  \n",
-    "# Creating figyre \n",
+    "# Creating figure \n",
     "fig = plt.figure(figsize =(14, 9)) \n",
     "ax = plt.axes(projection ='3d') \n",
     "  \n",


### PR DESCRIPTION
Just a small change - "figyre" to "figure"!